### PR TITLE
Allow ignoring some branches via action inputs

### DIFF
--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -1,6 +1,6 @@
 import {
   filterArray,
-  isBotPr,
+  shouldSkipBranchLint,
   getHotfixLabel,
   getPivotalId,
   getPodLabel,
@@ -11,17 +11,27 @@ import {
 } from '../src/utils';
 import { HIDDEN_MARKER } from '../src/constants';
 
-describe('isBotPr()', () => {
-  it('should return true for dependabot PR', () => {
-    expect(isBotPr('dependabot')).toBeTruthy();
+describe('shouldSkipBranchLint()', () => {
+  it('should recognize bot PRs', () => {
+    expect(shouldSkipBranchLint('dependabot')).toBeTruthy();
   });
 
-  it('should return false for non bot PR', () => {
-    expect(isBotPr('feature/awesomeNewFeature')).toBeFalsy();
+  it('should handle custom ignore patterns', () => {
+    expect(shouldSkipBranchLint('bar', '^bar')).toBeTruthy();
+    expect(shouldSkipBranchLint('foobar', '^bar')).toBeFalsy();
+
+    expect(shouldSkipBranchLint('bar', '[0-9]{2}')).toBeFalsy();
+    expect(shouldSkipBranchLint('bar', '')).toBeFalsy();
+    expect(shouldSkipBranchLint('foo', '[0-9]{2}')).toBeFalsy();
+    expect(shouldSkipBranchLint('f00', '[0-9]{2}')).toBeTruthy();
   });
 
   it('should return false with empty input', () => {
-    expect(isBotPr('')).toBeFalsy();
+    expect(shouldSkipBranchLint('')).toBeFalsy();
+  });
+
+  it('should return false for other branches', () => {
+    expect(shouldSkipBranchLint('feature/awesomeNewFeature')).toBeFalsy();
   });
 });
 

--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -11,7 +11,7 @@ import {
 } from '../src/utils';
 import { HIDDEN_MARKER } from '../src/constants';
 
-jest.spyOn(console, 'log').mockImplementation();
+jest.spyOn(console, 'log').mockImplementation(); // avoid actual console.log in test output
 
 describe('shouldSkipBranchLint()', () => {
   it('should recognize bot PRs', () => {

--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -11,6 +11,8 @@ import {
 } from '../src/utils';
 import { HIDDEN_MARKER } from '../src/constants';
 
+jest.spyOn(console, 'log').mockImplementation();
+
 describe('shouldSkipBranchLint()', () => {
   it('should recognize bot PRs', () => {
     expect(shouldSkipBranchLint('dependabot')).toBeTruthy();

--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -18,7 +18,7 @@ describe('shouldSkipBranchLint()', () => {
     expect(shouldSkipBranchLint('dependabot')).toBeTruthy();
   });
 
-  it('should handle custom ignore patterns', () => {
+  it.only('should handle custom ignore patterns', () => {
     expect(shouldSkipBranchLint('bar', '^bar')).toBeTruthy();
     expect(shouldSkipBranchLint('foobar', '^bar')).toBeFalsy();
 
@@ -26,6 +26,19 @@ describe('shouldSkipBranchLint()', () => {
     expect(shouldSkipBranchLint('bar', '')).toBeFalsy();
     expect(shouldSkipBranchLint('foo', '[0-9]{2}')).toBeFalsy();
     expect(shouldSkipBranchLint('f00', '[0-9]{2}')).toBeTruthy();
+
+    const customBranchRegex = '^(production-release|master|release\/v\\d+)$';
+    expect(shouldSkipBranchLint('production-release', customBranchRegex)).toBeTruthy();
+    expect(shouldSkipBranchLint('master', customBranchRegex)).toBeTruthy();
+    expect(shouldSkipBranchLint('release/v77', customBranchRegex)).toBeTruthy();
+
+    expect(shouldSkipBranchLint('release/very-important-feature', customBranchRegex)).toBeFalsy();
+    expect(shouldSkipBranchLint('masterful', customBranchRegex)).toBeFalsy();
+    expect(shouldSkipBranchLint('productionish', customBranchRegex)).toBeFalsy();
+    expect(shouldSkipBranchLint('fix/production-issue', customBranchRegex)).toBeFalsy();
+    expect(shouldSkipBranchLint('chore/rebase-with-master', customBranchRegex)).toBeFalsy();
+    expect(shouldSkipBranchLint('chore/rebase-with-release', customBranchRegex)).toBeFalsy();
+    expect(shouldSkipBranchLint('chore/rebase-with-release/v77', customBranchRegex)).toBeFalsy();
   });
 
   it('should return false with empty input', () => {

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,17 @@
 name: 'PR lint'
 description: 'Lint the PR'
 author: 'cleartax'
+inputs:
+  github-token:
+    description: Token used to update PR description. Must have write access to your repository.
+    required: true
+  pivotal-token:
+    description: API Token used to fetch Pivotal Story information.
+    required: true
+  branch-ignore-pattern:
+    description: A regex to ignore running PR lint on certain branches
+    required: false
+    default: ''
 runs:
   using: 'node12'
   main: 'lib/index.js'

--- a/jest.config.js
+++ b/jest.config.js
@@ -7,5 +7,6 @@ module.exports = {
   transform: {
     '^.+\\.ts$': 'ts-jest'
   },
-  verbose: true
-}
+  verbose: true,
+  collectCoverage: true,
+};

--- a/lib/index.js
+++ b/lib/index.js
@@ -4105,25 +4105,30 @@ exports.shouldUpdatePRDescription = (
 /** The PR description/body as a string. */
 body) => typeof body === 'string' && !constants_1.MARKER_REGEX.test(body);
 /**
+ * Return a safe value to output for story type.
+ * @param {StoryResponse} story
+ */
+const getEstimateForStoryType = (story) => {
+    const { story_type: type, estimate } = story;
+    if (type === 'feature') {
+        return typeof estimate !== 'undefined' ? estimate : 'unestimated';
+    }
+    return 'n/a';
+};
+/**
  * Get PR description with pivotal details
  * @param  {string=''} body
  * @param  {StoryResponse} story
  * @returns string
  */
 exports.getPrDescription = (body = '', story) => {
-    const { url, id, story_type, estimate, labels, description, name } = story;
+    const { url, id, story_type, labels, description, name } = story;
     const labelsArr = labels.map((label) => label.name).join(', ');
-    const estimateRow = story_type === 'feature' ? (`
-      <tr>
-        <td>Points</td>
-        <td>${estimate}</td
-      </tr>
-  `) : '';
     return `
 <h2><a href="${url}" target="_blank">Story #${id}</a></h2>
 
 <details open>
-  <summary> <strong>Pivotal Summary</strong> </summary>
+  <summary><strong>Pivotal Summary</strong></summary>
   <br />
   <table>
     <tr>
@@ -4141,7 +4146,11 @@ exports.getPrDescription = (body = '', story) => {
     <tr>
       <td>Type</td>
       <td>${exports.getStoryIcon(story_type)} ${story_type}</td>
-    </tr>${estimateRow}
+    </tr>
+    <tr>
+      <td>Points</td>
+      <td>${getEstimateForStoryType(story)}</td
+    </tr>
     <tr>
       <td>Labels</td>
       <td>${labelsArr}</td>
@@ -4150,10 +4159,9 @@ exports.getPrDescription = (body = '', story) => {
 </details>
 <br />
 <details>
-  <summary> <strong>Pivotal Description</strong></summary>
+  <summary><strong>Pivotal Description</strong></summary>
   <br />
   <p>${description || 'Oops, the story creator did not add any description.'}</p>
-  <br />
 </details>
 <!--
   do not remove this marker as it will break pr-lint's functionality.

--- a/lib/index.js
+++ b/lib/index.js
@@ -4065,8 +4065,11 @@ exports.filterArray = (arr) => (arr && arr.length ? arr.filter(x => x.trim()) : 
  */
 exports.shouldSkipBranchLint = (branch, additionalIgnorePattern) => {
     if (constants_1.BOT_BRANCH_PATTERNS.some(pattern => pattern.test(branch))) {
-        console.log("You look like a bot 🤖 so we're letting you off the hook!");
+        console.log(`You look like a bot 🤖 so we're letting you off the hook!`);
         return true;
+    }
+    if (constants_1.DEFAULT_BRANCH_PATTERNS.some(pattern => pattern.test(branch))) {
+        console.log(`Ignoring check for default branch ${branch}`);
     }
     const ignorePattern = new RegExp(additionalIgnorePattern || '');
     if (!!additionalIgnorePattern && ignorePattern.test(branch)) {
@@ -10441,6 +10444,11 @@ exports.HIDDEN_MARKER = 'added_by_pr_lint';
 exports.MARKER_REGEX = new RegExp(exports.HIDDEN_MARKER);
 exports.BOT_BRANCH_PATTERNS = [
     /dependabot/
+];
+exports.DEFAULT_BRANCH_PATTERNS = [
+    /^master$/,
+    /^production$/,
+    /^gh-pages$/,
 ];
 
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -4073,8 +4073,9 @@ exports.shouldSkipBranchLint = (branch, additionalIgnorePattern) => {
         return true;
     }
     const ignorePattern = new RegExp(additionalIgnorePattern || '');
+    console.log({ ignorePattern, additionalIgnorePattern });
     if (!!additionalIgnorePattern && ignorePattern.test(branch)) {
-        console.log(`branch '${branch}' ignored as it matches the ignore pattern '${additionalIgnorePattern}''`);
+        console.log(`branch '${branch}' ignored as it matches the ignore pattern '${additionalIgnorePattern}' provided in skip-branches`);
         return true;
     }
     return false;

--- a/lib/index.js
+++ b/lib/index.js
@@ -3365,6 +3365,7 @@ function run() {
         try {
             const PIVOTAL_TOKEN = core.getInput('pivotal-token', { required: true });
             const GITHUB_TOKEN = core.getInput('github-token', { required: true });
+            const BRANCH_IGNORE_PATTERN = core.getInput('skip-branches', { required: false }) || '';
             const { payload: { repository, organization, pull_request }, } = github.context;
             let headBranch = '';
             let baseBranch = '';
@@ -3378,8 +3379,7 @@ function run() {
             }
             console.log('Base branch -> ', baseBranch);
             console.log('Head branch -> ', headBranch);
-            if (utils_1.isBotPr(headBranch)) {
-                console.log("You look like a bot 🤖 so we're letting you off the hook!");
+            if (utils_1.shouldSkipBranchLint(headBranch, BRANCH_IGNORE_PATTERN)) {
                 process.exit(0);
             }
             const pivotalId = utils_1.getPivotalId(headBranch);
@@ -4057,13 +4057,24 @@ exports.updatePrDetails = (client, prData) => __awaiter(void 0, void 0, void 0, 
  */
 exports.filterArray = (arr) => (arr && arr.length ? arr.filter(x => x.trim()) : []);
 /**
- * Check if the PR is an automated one created by a bot
- * Can be extended to include other bots later
+ * Check if the PR is an automated one created by a bot or one matching ignore patterns supplied
+ * via action metadata.
  * @param {string} branch
- * @example isBotPr('dependabot') -> true
- * @example isBotPr('feature/update_123456789') -> false
+ * @example shouldSkipBranchLint('dependabot') -> true
+ * @example shouldSkipBranchLint('feature/update_123456789') -> false
  */
-exports.isBotPr = (branch) => (branch ? branch.includes('dependabot') : false);
+exports.shouldSkipBranchLint = (branch, additionalIgnorePattern) => {
+    if (constants_1.BOT_BRANCH_PATTERNS.some(pattern => pattern.test(branch))) {
+        console.log("You look like a bot 🤖 so we're letting you off the hook!");
+        return true;
+    }
+    const ignorePattern = new RegExp(additionalIgnorePattern || '');
+    if (!!additionalIgnorePattern && ignorePattern.test(branch)) {
+        console.log(`branch '${branch} ignored as it matches the ignore pattern '${additionalIgnorePattern}''`);
+        return true;
+    }
+    return false;
+};
 /**
  * Get icon based on the story type
  * @param  {string} storyType
@@ -10428,6 +10439,9 @@ exports.Deprecation = Deprecation;
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.HIDDEN_MARKER = 'added_by_pr_lint';
 exports.MARKER_REGEX = new RegExp(exports.HIDDEN_MARKER);
+exports.BOT_BRANCH_PATTERNS = [
+    /dependabot/
+];
 
 
 /***/ }),

--- a/lib/index.js
+++ b/lib/index.js
@@ -3366,6 +3366,7 @@ function run() {
             const PIVOTAL_TOKEN = core.getInput('pivotal-token', { required: true });
             const GITHUB_TOKEN = core.getInput('github-token', { required: true });
             const BRANCH_IGNORE_PATTERN = core.getInput('skip-branches', { required: false }) || '';
+            console.log({ BRANCH_IGNORE_PATTERN });
             const { payload: { repository, organization, pull_request }, } = github.context;
             let headBranch = '';
             let baseBranch = '';

--- a/lib/index.js
+++ b/lib/index.js
@@ -4070,10 +4070,11 @@ exports.shouldSkipBranchLint = (branch, additionalIgnorePattern) => {
     }
     if (constants_1.DEFAULT_BRANCH_PATTERNS.some(pattern => pattern.test(branch))) {
         console.log(`Ignoring check for default branch ${branch}`);
+        return true;
     }
     const ignorePattern = new RegExp(additionalIgnorePattern || '');
     if (!!additionalIgnorePattern && ignorePattern.test(branch)) {
-        console.log(`branch '${branch} ignored as it matches the ignore pattern '${additionalIgnorePattern}''`);
+        console.log(`branch '${branch}' ignored as it matches the ignore pattern '${additionalIgnorePattern}''`);
         return true;
     }
     return false;

--- a/lib/index.js
+++ b/lib/index.js
@@ -4077,6 +4077,7 @@ exports.shouldSkipBranchLint = (branch, additionalIgnorePattern) => {
         console.log(`branch '${branch}' ignored as it matches the ignore pattern '${additionalIgnorePattern}' provided in skip-branches`);
         return true;
     }
+    console.log(`branch '${branch}' does not match ignore pattern provided in 'skip-branches' option:`, ignorePattern);
     return false;
 };
 /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -4073,7 +4073,6 @@ exports.shouldSkipBranchLint = (branch, additionalIgnorePattern) => {
         return true;
     }
     const ignorePattern = new RegExp(additionalIgnorePattern || '');
-    console.log({ ignorePattern, additionalIgnorePattern });
     if (!!additionalIgnorePattern && ignorePattern.test(branch)) {
         console.log(`branch '${branch}' ignored as it matches the ignore pattern '${additionalIgnorePattern}' provided in skip-branches`);
         return true;

--- a/lib/index.js
+++ b/lib/index.js
@@ -4115,7 +4115,7 @@ const getEstimateForStoryType = (story) => {
     if (type === 'feature') {
         return typeof estimate !== 'undefined' ? estimate : 'unestimated';
     }
-    return 'n/a';
+    return 'N/A';
 };
 /**
  * Get PR description with pivotal details

--- a/lib/index.js
+++ b/lib/index.js
@@ -3960,9 +3960,9 @@ exports.LABELS = {
  * @param {string} baseBranch
  */
 exports.getHotfixLabel = (baseBranch) => {
-    if (baseBranch.includes('release/v'))
+    if (baseBranch.startsWith('release/v'))
         return exports.LABELS.HOTFIX_PRE_PROD;
-    if (baseBranch.includes('production'))
+    if (baseBranch.startsWith('production'))
         return exports.LABELS.HOTFIX_PROD;
     return '';
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -4149,7 +4149,7 @@ exports.getPrDescription = (body = '', story) => {
     </tr>
     <tr>
       <td>Points</td>
-      <td>${getEstimateForStoryType(story)}</td
+      <td>${getEstimateForStoryType(story)}</td>
     </tr>
     <tr>
       <td>Labels</td>

--- a/lib/index.js
+++ b/lib/index.js
@@ -3366,7 +3366,6 @@ function run() {
             const PIVOTAL_TOKEN = core.getInput('pivotal-token', { required: true });
             const GITHUB_TOKEN = core.getInput('github-token', { required: true });
             const BRANCH_IGNORE_PATTERN = core.getInput('skip-branches', { required: false }) || '';
-            console.log({ BRANCH_IGNORE_PATTERN });
             const { payload: { repository, organization, pull_request }, } = github.context;
             let headBranch = '';
             let baseBranch = '';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,2 +1,6 @@
 export const HIDDEN_MARKER = 'added_by_pr_lint';
 export const MARKER_REGEX = new RegExp(HIDDEN_MARKER);
+
+export const BOT_BRANCH_PATTERNS: RegExp[] = [
+  /dependabot/
+];

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,3 +4,9 @@ export const MARKER_REGEX = new RegExp(HIDDEN_MARKER);
 export const BOT_BRANCH_PATTERNS: RegExp[] = [
   /dependabot/
 ];
+
+export const DEFAULT_BRANCH_PATTERNS:  RegExp[] = [
+  /^master$/,
+  /^production$/,
+  /^gh-pages$/,
+];

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,8 +21,6 @@ async function run() {
     const GITHUB_TOKEN: string = core.getInput('github-token', { required: true });
     const BRANCH_IGNORE_PATTERN: string = core.getInput('skip-branches', { required: false }) || '';
 
-    console.log({ BRANCH_IGNORE_PATTERN });
-
     const {
       payload: { repository, organization, pull_request },
     } = github.context;

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,6 +21,8 @@ async function run() {
     const GITHUB_TOKEN: string = core.getInput('github-token', { required: true });
     const BRANCH_IGNORE_PATTERN: string = core.getInput('skip-branches', { required: false }) || '';
 
+    console.log({ BRANCH_IGNORE_PATTERN });
+
     const {
       payload: { repository, organization, pull_request },
     } = github.context;

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,7 +8,7 @@ import {
   addLabels,
   getPodLabel,
   filterArray,
-  isBotPr,
+  shouldSkipBranchLint,
   updatePrDetails,
   getPivotalId,
   getPrDescription,
@@ -19,6 +19,7 @@ async function run() {
   try {
     const PIVOTAL_TOKEN: string = core.getInput('pivotal-token', { required: true });
     const GITHUB_TOKEN: string = core.getInput('github-token', { required: true });
+    const BRANCH_IGNORE_PATTERN: string = core.getInput('skip-branches', { required: false }) || '';
 
     const {
       payload: { repository, organization, pull_request },
@@ -38,8 +39,7 @@ async function run() {
     console.log('Base branch -> ', baseBranch);
     console.log('Head branch -> ', headBranch);
 
-    if (isBotPr(headBranch)) {
-      console.log("You look like a bot 🤖 so we're letting you off the hook!");
+    if (shouldSkipBranchLint(headBranch, BRANCH_IGNORE_PATTERN)) {
       process.exit(0);
     }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -216,26 +216,32 @@ export const shouldUpdatePRDescription = (
 ): boolean => typeof body === 'string' && !MARKER_REGEX.test(body);
 
 /**
+ * Return a safe value to output for story type.
+ * @param {StoryResponse} story
+ */
+const getEstimateForStoryType = (story: StoryResponse) => {
+  const { story_type: type, estimate } = story;
+  if (type === 'feature') {
+    return typeof estimate !== 'undefined' ? estimate : 'unestimated';
+  }
+  return 'n/a';
+};
+
+/**
  * Get PR description with pivotal details
  * @param  {string=''} body
  * @param  {StoryResponse} story
  * @returns string
  */
 export const getPrDescription = (body: string = '', story: StoryResponse): string => {
-  const { url, id, story_type, estimate, labels, description, name } = story;
+  const { url, id, story_type, labels, description, name } = story;
   const labelsArr = labels.map((label: { name: string }) => label.name).join(', ');
 
-  const estimateRow =  story_type === 'feature' ? (`
-      <tr>
-        <td>Points</td>
-        <td>${estimate}</td
-      </tr>
-  `): '';
   return `
 <h2><a href="${url}" target="_blank">Story #${id}</a></h2>
 
 <details open>
-  <summary> <strong>Pivotal Summary</strong> </summary>
+  <summary><strong>Pivotal Summary</strong></summary>
   <br />
   <table>
     <tr>
@@ -253,7 +259,11 @@ export const getPrDescription = (body: string = '', story: StoryResponse): strin
     <tr>
       <td>Type</td>
       <td>${getStoryIcon(story_type)} ${story_type}</td>
-    </tr>${estimateRow}
+    </tr>
+    <tr>
+      <td>Points</td>
+      <td>${getEstimateForStoryType(story)}</td
+    </tr>
     <tr>
       <td>Labels</td>
       <td>${labelsArr}</td>
@@ -262,10 +272,9 @@ export const getPrDescription = (body: string = '', story: StoryResponse): strin
 </details>
 <br />
 <details>
-  <summary> <strong>Pivotal Description</strong></summary>
+  <summary><strong>Pivotal Description</strong></summary>
   <br />
   <p>${description || 'Oops, the story creator did not add any description.'}</p>
-  <br />
 </details>
 <!--
   do not remove this marker as it will break pr-lint's functionality.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -176,11 +176,12 @@ export const shouldSkipBranchLint = (branch: string, additionalIgnorePattern?: s
 
   if (DEFAULT_BRANCH_PATTERNS.some(pattern => pattern.test(branch))) {
     console.log(`Ignoring check for default branch ${branch}`);
+    return true;
   }
 
   const ignorePattern = new RegExp(additionalIgnorePattern || '');
   if (!!additionalIgnorePattern && ignorePattern.test(branch)) {
-    console.log(`branch '${branch} ignored as it matches the ignore pattern '${additionalIgnorePattern}''`)
+    console.log(`branch '${branch}' ignored as it matches the ignore pattern '${additionalIgnorePattern}''`)
     return true;
   }
   return false;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -180,8 +180,10 @@ export const shouldSkipBranchLint = (branch: string, additionalIgnorePattern?: s
   }
 
   const ignorePattern = new RegExp(additionalIgnorePattern || '');
+
+  console.log({ ignorePattern, additionalIgnorePattern });
   if (!!additionalIgnorePattern && ignorePattern.test(branch)) {
-    console.log(`branch '${branch}' ignored as it matches the ignore pattern '${additionalIgnorePattern}''`)
+    console.log(`branch '${branch}' ignored as it matches the ignore pattern '${additionalIgnorePattern}' provided in skip-branches`)
     return true;
   }
   return false;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,7 +2,7 @@ import axios from 'axios';
 import * as core from '@actions/core';
 import * as github from '@actions/github';
 import { IssuesAddLabelsParams, PullsUpdateParams } from '@octokit/rest';
-import { MARKER_REGEX, HIDDEN_MARKER, BOT_BRANCH_PATTERNS } from './constants';
+import { MARKER_REGEX, HIDDEN_MARKER, BOT_BRANCH_PATTERNS, DEFAULT_BRANCH_PATTERNS } from './constants';
 
 /**
  *  Extract pivotal id from the branch name
@@ -170,8 +170,12 @@ export const filterArray = (arr: string[]): string[] => (arr && arr.length ? arr
  */
 export const shouldSkipBranchLint = (branch: string, additionalIgnorePattern?: string): boolean => {
   if (BOT_BRANCH_PATTERNS.some(pattern => pattern.test(branch))) {
-    console.log("You look like a bot 🤖 so we're letting you off the hook!");
+    console.log(`You look like a bot 🤖 so we're letting you off the hook!`);
     return true;
+  }
+
+  if (DEFAULT_BRANCH_PATTERNS.some(pattern => pattern.test(branch))) {
+    console.log(`Ignoring check for default branch ${branch}`);
   }
 
   const ignorePattern = new RegExp(additionalIgnorePattern || '');

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -180,8 +180,6 @@ export const shouldSkipBranchLint = (branch: string, additionalIgnorePattern?: s
   }
 
   const ignorePattern = new RegExp(additionalIgnorePattern || '');
-
-  console.log({ ignorePattern, additionalIgnorePattern });
   if (!!additionalIgnorePattern && ignorePattern.test(branch)) {
     console.log(`branch '${branch}' ignored as it matches the ignore pattern '${additionalIgnorePattern}' provided in skip-branches`)
     return true;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -262,7 +262,7 @@ export const getPrDescription = (body: string = '', story: StoryResponse): strin
     </tr>
     <tr>
       <td>Points</td>
-      <td>${getEstimateForStoryType(story)}</td
+      <td>${getEstimateForStoryType(story)}</td>
     </tr>
     <tr>
       <td>Labels</td>

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -184,6 +184,8 @@ export const shouldSkipBranchLint = (branch: string, additionalIgnorePattern?: s
     console.log(`branch '${branch}' ignored as it matches the ignore pattern '${additionalIgnorePattern}' provided in skip-branches`)
     return true;
   }
+
+  console.log(`branch '${branch}' does not match ignore pattern provided in 'skip-branches' option:`, ignorePattern);
   return false;
 };
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -227,7 +227,7 @@ const getEstimateForStoryType = (story: StoryResponse) => {
   if (type === 'feature') {
     return typeof estimate !== 'undefined' ? estimate : 'unestimated';
   }
-  return 'n/a';
+  return 'N/A';
 };
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -26,8 +26,8 @@ export const LABELS = {
  * @param {string} baseBranch
  */
 export const getHotfixLabel = (baseBranch: string): string => {
-  if (baseBranch.includes('release/v')) return LABELS.HOTFIX_PRE_PROD;
-  if (baseBranch.includes('production')) return LABELS.HOTFIX_PROD;
+  if (baseBranch.startsWith('release/v')) return LABELS.HOTFIX_PRE_PROD;
+  if (baseBranch.startsWith('production')) return LABELS.HOTFIX_PROD;
   return '';
 };
 


### PR DESCRIPTION
You can now ignore certain branches via the `skip-branches` input.